### PR TITLE
Add missing `key` and `string` tags

### DIFF
--- a/Preferences/Typing Pairs: Block Opening.tmPreferences
+++ b/Preferences/Typing Pairs: Block Opening.tmPreferences
@@ -4,6 +4,8 @@
 <dict>
 	<key>name</key>
 	<string>Typing Pairs: Block Opening</string>
+	<key>scope</key>
+	<string>source.smalltalk</string>
 	<key>settings</key>
 	<dict>
 		<key>smartTypingPairs</key>


### PR DESCRIPTION
This'll prevent Sublime Text from complaining.

@tomas-stefano
