### PR TITLE
Various Improvements and Cleanup

### DIFF
--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -51,6 +51,31 @@ end</string>
 	<string>Run</string>
 	<key>output</key>
 	<string>showAsHTML</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>gst</string>
+			<key>locations</key>
+			<array>
+				<string>/opt/local/bin/gst</string>
+				<string>/usr/local/bin/gst</string>
+			</array>
+			<key>variable</key>
+			<string>TM_SMALLTALK</string>
+		</dict>
+		<dict>
+			<key>command</key>
+			<string>gst-sunit</string>
+			<key>locations</key>
+			<array>
+				<string>/opt/local/bin/gst-sunit</string>
+				<string>/usr/local/bin/gst-sunit</string>
+			</array>
+			<key>variable</key>
+			<string>TM_SMALLTALK_TEST</string>
+		</dict>
+	</array>
 	<key>scope</key>
 	<string>source.smalltalk</string>
 	<key>uuid</key>

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -1,11 +1,8 @@
-# Textmate Bundle for SmallTalk development
+# Textmate 2 Bundle for Smalltalk development
 
-## Install
+## Installation
 
-    mkdir -p ~/Library/Application\ Support/TextMate/Bundles
-    cd ~/Library/Application\ Support/TextMate/Bundles
-    git clone git://github.com/tomas-stefano/smalltalk-tmbundle.git "Smalltalk.tmbundle"
-    osascript -e 'tell app "TextMate" to reload bundles'
+You can install this bundle in TextMate by opening the preferences and going to the bundles tab. After installation it will be automatically updated for you.
 
 ## Open files
 

--- a/Snippets/class 2.tmSnippet
+++ b/Snippets/class 2.tmSnippet
@@ -4,9 +4,9 @@
 <dict>
 	<key>content</key>
 	<string>Object subclass: ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.st)?/(?2::\u$1)/g}} [
-  &lt;category: '$2'&gt;
-  &lt;comment: '$3'&gt;
-  $0
+	&lt;category: '$2'&gt;
+	&lt;comment: '$3'&gt;
+	$0
 ]</string>
 	<key>name</key>
 	<string>class (Object subclass: ...)</string>

--- a/Snippets/class 2.tmSnippet
+++ b/Snippets/class 2.tmSnippet
@@ -9,7 +9,7 @@
 	$0
 ]</string>
 	<key>name</key>
-	<string>class (Object subclass: ...)</string>
+	<string>class (Object subclass: …)</string>
 	<key>scope</key>
 	<string>source.smalltalk</string>
 	<key>tabTrigger</key>

--- a/Snippets/class instance variables ___.tmSnippet
+++ b/Snippets/class instance variables ___.tmSnippet
@@ -11,7 +11,7 @@
 
 	$0</string>
 	<key>name</key>
-	<string>class instance variables ...</string>
+	<string>class instance variables …</string>
 	<key>scope</key>
 	<string>source.smalltalk</string>
 	<key>tabTrigger</key>

--- a/Snippets/class instance variables ___.tmSnippet
+++ b/Snippets/class instance variables ___.tmSnippet
@@ -4,12 +4,12 @@
 <dict>
 	<key>content</key>
 	<string>${1:Object} subclass: #${2:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.st)?/(?2::\u$1)/g}}
-  instanceVariableNames: '$3' 
-  classVariableNames: '$4'
-  poolDictionaries: '$5' 
-  category: '$6'
+	instanceVariableNames: '$3' 
+	classVariableNames: '$4'
+	poolDictionaries: '$5' 
+	category: '$6'
 
-  $0</string>
+	$0</string>
 	<key>name</key>
 	<string>class instance variables ...</string>
 	<key>scope</key>

--- a/Snippets/class.tmSnippet
+++ b/Snippets/class.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>Object subclass: ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.st)?/(?2::\u$1)/g}} [
-  $0
+	$0
 ]</string>
 	<key>name</key>
 	<string>class (without category)</string>

--- a/Snippets/class_method.tmSnippet
+++ b/Snippets/class_method.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.st)?/(?2::\u$1)/g}} class &gt;&gt; ${2:method_name} [
-  $0
+	$0
 ]</string>
 	<key>name</key>
 	<string>class_method</string>

--- a/Snippets/eval.tmSnippet
+++ b/Snippets/eval.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>Eval [
-  $0
+	$0
 ]</string>
 	<key>name</key>
 	<string>eval</string>

--- a/Snippets/method.tmSnippet
+++ b/Snippets/method.tmSnippet
@@ -4,8 +4,8 @@
 <dict>
 	<key>content</key>
 	<string>${1:method_name} [
-  &lt;category: '${2:accessing}'&gt;
-  $0
+	&lt;category: '${2:accessing}'&gt;
+	$0
 ]</string>
 	<key>name</key>
 	<string>method</string>

--- a/Syntaxes/SmallTalk.tmLanguage
+++ b/Syntaxes/SmallTalk.tmLanguage
@@ -152,7 +152,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\w*\s)+(\s*(subclass:))+\s*(\w*)</string>
+			<string>(\w+)(\s+(subclass:))\s*(\w*)</string>
 			<key>name</key>
 			<string>meta.class.smalltalk</string>
 		</dict>

--- a/Syntaxes/SmallTalk.tmLanguage
+++ b/Syntaxes/SmallTalk.tmLanguage
@@ -68,7 +68,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\|)+([\w\ ]+)+(\|)</string>
+			<string>(\|)(\s*\w[\w ]*)(\|)</string>
 		</dict>
 		<dict>
 			<key>captures</key>

--- a/Syntaxes/SmallTalk.tmLanguage
+++ b/Syntaxes/SmallTalk.tmLanguage
@@ -42,7 +42,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.separator.variable.smalltalk</string>
+					<string>punctuation.definition.instance-variables.begin.smalltalk</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -52,7 +52,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.separator.variable.smalltalk</string>
+					<string>punctuation.definition.instance-variables.end.smalltalk</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -133,16 +133,38 @@
 		<dict>
 			<key>begin</key>
 			<string>"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.begin.smalltalk</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>"</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.end.smalltalk</string>
+				</dict>
+			</dict>
 			<key>name</key>
-			<string>comment.language.smalltalk</string>
+			<string>comment.block.smalltalk</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(true|false|nil)\b</string>
+			<string>\b(true|false)\b</string>
 			<key>name</key>
-			<string>constant.language.smalltalk</string>
+			<string>constant.language.boolean.smalltalk</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(nil)\b</string>
+			<key>name</key>
+			<string>constant.language.nil.smalltalk</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -161,40 +183,96 @@
 			<string>constant.other.messages.smalltalk</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.constant.smalltalk</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>symbols</string>
 			<key>match</key>
-			<string>#[a-zA-Z_][a-zA-Z0-9_:]*</string>
+			<string>(#)[a-zA-Z_][a-zA-Z0-9_:]*</string>
 			<key>name</key>
 			<string>constant.other.symbol.smalltalk</string>
 		</dict>
 		<dict>
 			<key>begin</key>
 			<string>#\[</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.constant.begin.smalltalk</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>ByteArray Constructor. Unfortunely this dont validate only numbers. TODO.</string>
 			<key>end</key>
 			<string>\]</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.constant.end.smalltalk</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>constant.other.bytearray.smalltalk</string>
 		</dict>
 		<dict>
 			<key>begin</key>
 			<string>#\(</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.constant.begin.smalltalk</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Array Constructor</string>
 			<key>end</key>
 			<string>\)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.constant.end.smalltalk</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>constant.other.array.smalltalk</string>
 		</dict>
 		<dict>
 			<key>begin</key>
 			<string>'</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.smalltalk</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>'</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.smalltalk</string>
+				</dict>
+			</dict>
 			<key>name</key>
-			<string>string.smalltalk</string>
+			<string>string.quoted.single.smalltalk</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/Syntaxes/SmallTalk.tmLanguage
+++ b/Syntaxes/SmallTalk.tmLanguage
@@ -18,9 +18,21 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>\b(super|self|yourself|new|extend|class|Smalltalk)\b</string>
+			<string>\b(class)\b</string>
 			<key>name</key>
-			<string>keyword.language.smalltalk</string>
+			<string>storage.type.$1.smalltalk</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(extend|super|self)\b</string>
+			<key>name</key>
+			<string>storage.modifier.$1.smalltalk</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(yourself|new|Smalltalk)\b</string>
+			<key>name</key>
+			<string>keyword.control.$1.smalltalk</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/Syntaxes/SmallTalk.tmLanguage
+++ b/Syntaxes/SmallTalk.tmLanguage
@@ -140,7 +140,7 @@
 					<key>name</key>
 					<string>entity.other.inherited-class.smalltalk</string>
 				</dict>
-				<key>2</key>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.control.smalltalk</string>

--- a/Syntaxes/SmallTalk.tmLanguage
+++ b/Syntaxes/SmallTalk.tmLanguage
@@ -58,8 +58,15 @@
 				</dict>
 				<key>2</key>
 				<dict>
-					<key>name</key>
-					<string>support.type.variable.declaration.smalltalk</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>\w+</string>
+							<key>name</key>
+							<string>support.type.variable.declaration.smalltalk</string>
+						</dict>
+					</array>
 				</dict>
 				<key>3</key>
 				<dict>
@@ -75,14 +82,21 @@
 			<dict>
 				<key>1</key>
 				<dict>
-					<key>name</key>
-					<string>entity.name.function.block.smalltalk</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>:\w+</string>
+							<key>name</key>
+							<string>entity.name.function.block.smalltalk</string>
+						</dict>
+					</array>
 				</dict>
 			</dict>
 			<key>comment</key>
 			<string>Parse the blocks like: [ :a :b | ...... ]</string>
 			<key>match</key>
-			<string>\[\s{0,}(:{1,}[\w\ ]+.*\|)</string>
+			<string>\[((\s+|:\w+)*)\|</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/info.plist
+++ b/info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>description</key>
+	<string>An object-oriented, dynamically typed, reflective programming language.</string>
 	<key>mainMenu</key>
 	<dict>
 		<key>items</key>

--- a/info.plist
+++ b/info.plist
@@ -2,30 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>mainMenu</key>
+	<dict>
+		<key>items</key>
+		<array>
+			<string>A18BF16A-DF88-41F4-A2ED-736CD2DBB7A6</string>
+			<string>------------------------------------</string>
+			<string>17ED16BD-18DB-42D9-8105-04D4C69A6268</string>
+			<string>19B8887F-DA51-4F63-B2DE-4A2022F44F86</string>
+			<string>91DEAE5D-3FD1-4CDF-BD3A-E5A7665ECD2D</string>
+			<string>FE8F5FFC-27A1-4214-9DC0-5D06699A8343</string>
+			<string>5E80AA6F-DF85-49BA-8720-B646F6D69279</string>
+			<string>58AAE5AB-4023-4143-8219-6C642B62F6C6</string>
+			<string>F809A1A0-8D3E-416A-8782-C921068CCBD1</string>
+			<string>D23E1F7C-D3FC-420A-8712-00100EB30667</string>
+			<string>2F35E812-57C5-47EF-9797-6A239E399990</string>
+			<string>1C6D02CD-C031-46F0-AE13-31ADDEFCEF3D</string>
+			<string>9E317597-7595-472D-B3A9-9BE9882A6636</string>
+			<string>372A165A-0EAB-4FCC-A2EC-CF402875CBEA</string>
+			<string>6FFBF0B8-8F29-48A5-B277-406A3DB42088</string>
+			<string>0B2C3393-1E70-4040-8865-74CE313067F6</string>
+		</array>
+	</dict>
 	<key>name</key>
 	<string>Smalltalk</string>
-	<key>ordering</key>
-	<array>
-		<string>A18BF16A-DF88-41F4-A2ED-736CD2DBB7A6</string>
-		<string>19B8887F-DA51-4F63-B2DE-4A2022F44F86</string>
-		<string>F809A1A0-8D3E-416A-8782-C921068CCBD1</string>
-		<string>2F35E812-57C5-47EF-9797-6A239E399990</string>
-		<string>372A165A-0EAB-4FCC-A2EC-CF402875CBEA</string>
-		<string>1C6D02CD-C031-46F0-AE13-31ADDEFCEF3D</string>
-		<string>9E317597-7595-472D-B3A9-9BE9882A6636</string>
-		<string>6FFBF0B8-8F29-48A5-B277-406A3DB42088</string>
-		<string>5E80AA6F-DF85-49BA-8720-B646F6D69279</string>
-		<string>17ED16BD-18DB-42D9-8105-04D4C69A6268</string>
-		<string>91DEAE5D-3FD1-4CDF-BD3A-E5A7665ECD2D</string>
-		<string>58AAE5AB-4023-4143-8219-6C642B62F6C6</string>
-		<string>FE8F5FFC-27A1-4214-9DC0-5D06699A8343</string>
-		<string>0B2C3393-1E70-4040-8865-74CE313067F6</string>
-		<string>D23E1F7C-D3FC-420A-8712-00100EB30667</string>
-		<string>1ED64A34-BCB1-44E1-A0FE-84053003E232</string>
-		<string>7B56E0CB-9A44-4D46-A329-AB12F074BAED</string>
-		<string>55D8E1F1-0078-41BB-BEAA-6D14A8FC6D18</string>
-		<string>8D85139E-E813-4683-910B-DB296AA409CA</string>
-	</array>
 	<key>uuid</key>
 	<string>7471537C-4EC6-4CCF-B93A-F087986CA465</string>
 </dict>


### PR DESCRIPTION
Got a request to add a smalltalk bundle to the 2.0 installer and this bundle appeared to be the best around. Made some minor improvements as I reviewed the bundle and corrected a recursion bug in one regexp that was causing some speed issues.

I have updated the readme to be 2.0 specific as a few of the grammar changes will not work for 1.x. The way we handled this in our bundles is to create a branch or tag at the last commit supported by 1.x so that can still be obtained for those users. (The 2.0 changes are support by [@github/linguist](https://github.com/github/linguist).)

Ask if you have any questions about the changes made.
